### PR TITLE
Fix link syntax to source-repository

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -28,7 +28,7 @@ concern. Especially for fixing bugs it is crucial that the developers can reprod
 entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
 
 Of course, patches are welcome, too. Contributors can check out the project from the
-[source repository](./source-repository.html and will find supplementary information in the
+[source repository](./source-repository.html) and will find supplementary information in the
 [guide to helping with Maven](http://maven.apache.org/guides/development/guide-helping.html).
 
 


### PR DESCRIPTION
On the Introduction page there is a missing ) which leads to a non-working link. This will fix it.
