### PR TITLE
Attach checksums as build artifacts

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactAttacher.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactAttacher.java
@@ -1,0 +1,21 @@
+package net.nicoulaj.maven.plugins.checksum.artifacts;
+
+import java.io.File;
+
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+
+public class ArtifactAttacher implements ArtifactListener {
+    private final MavenProject project;
+    private final MavenProjectHelper projectHelper;
+
+    public ArtifactAttacher(MavenProject project, MavenProjectHelper projectHelper) {
+        this.project = project;
+        this.projectHelper = projectHelper;
+    }
+
+    @Override
+    public void artifactCreated(File artifact, String type) {
+        projectHelper.attachArtifact(project, type, null, artifact);
+    }
+}

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactListener.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactListener.java
@@ -1,0 +1,7 @@
+package net.nicoulaj.maven.plugins.checksum.artifacts;
+
+import java.io.File;
+
+public interface ArtifactListener {
+    void artifactCreated(File artifact, String type);
+}

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
@@ -15,14 +15,15 @@
  */
 package net.nicoulaj.maven.plugins.checksum.execution.target;
 
-import org.codehaus.plexus.util.FileUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import net.nicoulaj.maven.plugins.checksum.artifacts.ArtifactListener;
+import org.codehaus.plexus.util.FileUtils;
 
 /**
  * An {@link ExecutionTarget} that writes digests to a CSV file.
@@ -69,15 +70,23 @@ public class CsvSummaryFileTarget
     protected File summaryFile;
 
     /**
-     * Build a new instance of {@link CsvSummaryFileTarget}.
+     * List of listeners which are notified every time a CSV file is created.
      *
+     * @since 1.3
+     */
+    protected final Iterable<? extends ArtifactListener> artifactListeners;
+
+    /**
+     * Build a new instance of {@link CsvSummaryFileTarget}.
      * @param summaryFile the file to which the summary should be written.
      * @param encoding    the encoding to use for generated files.
+     * @param artifactListeners
      */
-    public CsvSummaryFileTarget( File summaryFile, String encoding )
+    public CsvSummaryFileTarget(File summaryFile, String encoding, Iterable<? extends ArtifactListener> artifactListeners)
     {
         this.summaryFile = summaryFile;
         this.encoding = encoding;
+        this.artifactListeners = artifactListeners;
     }
 
     /**
@@ -145,6 +154,9 @@ public class CsvSummaryFileTarget
         try
         {
             FileUtils.fileWrite( summaryFile.getPath(), encoding, sb.toString() );
+            for (ArtifactListener artifactListener : artifactListeners) {
+                artifactListener.artifactCreated(summaryFile, "csv");
+            }
         }
         catch ( IOException e )
         {

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/OneHashPerFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/OneHashPerFileTarget.java
@@ -43,7 +43,7 @@ public class OneHashPerFileTarget
     protected File outputDirectory;
 
     /**
-     * List of listeners which are notified every time a CSV file is created.
+     * List of listeners which are notified every time a checksum file is created.
      *
      * @since 1.3
      */

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
@@ -15,10 +15,6 @@
  */
 package net.nicoulaj.maven.plugins.checksum.execution.target;
 
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
-import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -28,6 +24,11 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+
+import net.nicoulaj.maven.plugins.checksum.artifacts.ArtifactListener;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter;
 
 /**
  * An {@link net.nicoulaj.maven.plugins.checksum.execution.target.ExecutionTarget} that writes digests to an XML file.
@@ -59,15 +60,23 @@ public class XmlSummaryFileTarget
     protected File summaryFile;
 
     /**
-     * Build a new instance of {@link net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget}.
+     * List of listeners which are notified every time a CSV file is created.
      *
-     * @param summaryFile the file to which the summary should be written.
-     * @param encoding    the encoding to use for generated files.
+     * @since 1.3
      */
-    public XmlSummaryFileTarget( File summaryFile, String encoding )
+    protected final Iterable<? extends ArtifactListener> artifactListeners;
+
+    /**
+     * Build a new instance of {@link net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget}.
+     *  @param summaryFile the file to which the summary should be written.
+     * @param encoding    the encoding to use for generated files.
+     * @param artifactListeners
+     */
+    public XmlSummaryFileTarget(File summaryFile, String encoding, Iterable<? extends ArtifactListener> artifactListeners)
     {
         this.summaryFile = summaryFile;
         this.encoding = encoding;
+        this.artifactListeners = artifactListeners;
     }
 
     /**
@@ -142,6 +151,9 @@ public class XmlSummaryFileTarget
         try
         {
             outputStream.close();
+            for (ArtifactListener artifactListener : artifactListeners) {
+                artifactListener.artifactCreated(summaryFile, "xml");
+            }
         }
         catch ( IOException e )
         {

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
@@ -60,7 +60,7 @@ public class XmlSummaryFileTarget
     protected File summaryFile;
 
     /**
-     * List of listeners which are notified every time a CSV file is created.
+     * List of listeners which are notified every time a XML file is created.
      *
      * @since 1.3
      */

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
@@ -15,7 +15,14 @@
  */
 package net.nicoulaj.maven.plugins.checksum.mojo;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import net.nicoulaj.maven.plugins.checksum.Constants;
+import net.nicoulaj.maven.plugins.checksum.artifacts.ArtifactAttacher;
+import net.nicoulaj.maven.plugins.checksum.artifacts.ArtifactListener;
 import net.nicoulaj.maven.plugins.checksum.execution.Execution;
 import net.nicoulaj.maven.plugins.checksum.execution.ExecutionException;
 import net.nicoulaj.maven.plugins.checksum.execution.FailOnErrorExecution;
@@ -27,14 +34,12 @@ import net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
-
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Base class for {@code checksum-maven-plugin} mojos.
@@ -53,6 +58,16 @@ abstract class AbstractChecksumMojo
      */
     @Parameter( property = "project", required = true, readonly = true )
     protected MavenProject project;
+
+    /**
+     * The Maven Project Helper.
+     *
+     * Used to attach checksums as build artifacts.
+     *
+     * @since 1.3
+     */
+    @Component
+    protected MavenProjectHelper projectHelper;
 
     /**
      * The list of checksum algorithms used.
@@ -89,6 +104,14 @@ abstract class AbstractChecksumMojo
     protected String encoding = Constants.DEFAULT_ENCODING;
 
     /**
+     * Should the checksums be attached as build artifacts.
+     *
+     * @since 1.3
+     */
+    @Parameter( property = "attachChecksums", defaultValue = "false")
+    protected boolean attachChecksums;
+
+    /**
      * Indicates whether the build will print checksums in the build log.
      *
      * @since 1.0
@@ -118,19 +141,19 @@ abstract class AbstractChecksumMojo
                 outputDirectory = FileUtils.resolveFile( new File( project.getBuild().getDirectory() ),
                                                          getIndividualFilesOutputDirectory() );
             }
-            execution.addTarget( new OneHashPerFileTarget( encoding, outputDirectory ) );
+            execution.addTarget( new OneHashPerFileTarget( encoding, outputDirectory, createArtifactListeners()) );
         }
         if ( isCsvSummary() )
         {
             execution.addTarget( new CsvSummaryFileTarget(
                 FileUtils.resolveFile( new File( project.getBuild().getDirectory() ), getCsvSummaryFile() ),
-                encoding ) );
+                encoding, createArtifactListeners()) );
         }
         if ( isXmlSummary() )
         {
             execution.addTarget( new XmlSummaryFileTarget(
                 FileUtils.resolveFile( new File( project.getBuild().getDirectory() ), getXmlSummaryFile() ),
-                encoding ) );
+                encoding, createArtifactListeners()) );
         }
 
         // Run the execution.
@@ -143,6 +166,13 @@ abstract class AbstractChecksumMojo
             getLog().error( e.getMessage() );
             throw new MojoFailureException( e.getMessage() );
         }
+    }
+
+    private Iterable<? extends ArtifactListener> createArtifactListeners() {
+        if (!attachChecksums) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(new ArtifactAttacher(project, projectHelper));
     }
 
     /**

--- a/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/execution/target/ExecutionTargetsTest.java
+++ b/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/execution/target/ExecutionTargetsTest.java
@@ -15,7 +15,13 @@
  */
 package net.nicoulaj.maven.plugins.checksum.test.unit.execution.target;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
 import net.nicoulaj.maven.plugins.checksum.Constants;
+import net.nicoulaj.maven.plugins.checksum.artifacts.ArtifactListener;
 import net.nicoulaj.maven.plugins.checksum.execution.target.CsvSummaryFileTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.ExecutionTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.MavenLogTarget;
@@ -23,10 +29,6 @@ import net.nicoulaj.maven.plugins.checksum.execution.target.OneHashPerFileTarget
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Tests for {@link net.nicoulaj.maven.plugins.checksum.execution.target.ExecutionTarget} implementations.
@@ -51,9 +53,10 @@ public class ExecutionTargetsTest
     @Parameterized.Parameters
     public static Collection<Object[]> getTestParameters()
     {
+        Iterable<? extends ArtifactListener> artifactListeners = Collections.emptyList();
         Object[][] data =
-            new Object[][]{ { new MavenLogTarget( null ) }, { new OneHashPerFileTarget( Constants.DEFAULT_ENCODING ) },
-                { new CsvSummaryFileTarget( new File( "" ), Constants.DEFAULT_ENCODING ) } };
+            new Object[][]{ { new MavenLogTarget( null ) }, { new OneHashPerFileTarget( Constants.DEFAULT_ENCODING, artifactListeners) },
+                { new CsvSummaryFileTarget( new File( "" ), Constants.DEFAULT_ENCODING, artifactListeners) } };
         return Arrays.asList( data );
     }
 

--- a/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/execution/target/OneHashPerFileTargetTest.java
+++ b/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/execution/target/OneHashPerFileTargetTest.java
@@ -15,6 +15,13 @@
  */
 package net.nicoulaj.maven.plugins.checksum.test.unit.execution.target;
 
+import java.io.File;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.List;
+
+import net.nicoulaj.maven.plugins.checksum.artifacts.ArtifactListener;
 import net.nicoulaj.maven.plugins.checksum.digest.DigesterFactory;
 import net.nicoulaj.maven.plugins.checksum.execution.target.ExecutionTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.ExecutionTargetWriteException;
@@ -23,11 +30,6 @@ import net.nicoulaj.maven.plugins.checksum.test.unit.Constants;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
 
 /**
  * Tests for the {@link net.nicoulaj.maven.plugins.checksum.execution.target.OneHashPerFileTarget} {@link
@@ -41,7 +43,7 @@ public class OneHashPerFileTargetTest
      * The instance of {@link net.nicoulaj.maven.plugins.checksum.execution.target.OneHashPerFileTarget} used for the
      * test.
      */
-    ExecutionTarget target = new OneHashPerFileTarget( net.nicoulaj.maven.plugins.checksum.Constants.DEFAULT_ENCODING );
+    ExecutionTarget target = new OneHashPerFileTarget( net.nicoulaj.maven.plugins.checksum.Constants.DEFAULT_ENCODING, Collections.<ArtifactListener>emptyList());
 
     /**
      * Assert the target writes the right content to the right file.


### PR DESCRIPTION
Added a new parameter `attachChecksums` which enables attaching generated files as build artifacts.

Fixes #30