### PR TITLE
Support for paths in summary files and per-directory summary files

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.execution.target;
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
@@ -69,6 +69,11 @@ public class CsvSummaryFileTarget
     protected File summaryFile;
 
     /**
+     * The root path to be removed from summary files.
+     */
+    protected String summaryRoot;
+
+    /**
      * Build a new instance of {@link CsvSummaryFileTarget}.
      *
      * @param summaryFile the file to which the summary should be written.
@@ -78,6 +83,20 @@ public class CsvSummaryFileTarget
     {
         this.summaryFile = summaryFile;
         this.encoding = encoding;
+    }
+
+    /**
+     * Build a new instance of {@link CsvSummaryFileTarget}.
+     *
+     * @param summaryFile the file to which the summary should be written.
+     * @param encoding    the encoding to use for generated files.
+     * @param summaryRoot the root path to remove from filepaths prior to writing to the summary file.
+     */
+    public CsvSummaryFileTarget( File summaryFile, String encoding, String summaryRoot )
+    {
+        this.summaryFile = summaryFile;
+        this.encoding = encoding;
+        this.summaryRoot = summaryRoot;
     }
 
     /**
@@ -126,7 +145,7 @@ public class CsvSummaryFileTarget
         // Write a line for each file.
         for ( File file : filesHashcodes.keySet() )
         {
-            sb.append( LINE_SEPARATOR ).append( file.getName() );
+            sb.append( LINE_SEPARATOR ).append( stripSummaryRoot(file) );
             Map<String, String> fileHashcodes = filesHashcodes.get( file );
             for ( String algorithm : algorithms )
             {
@@ -150,5 +169,12 @@ public class CsvSummaryFileTarget
         {
             throw new ExecutionTargetCloseException( e.getMessage() );
         }
+    }
+
+    private String stripSummaryRoot(File file) {
+        if (summaryRoot != null && file.getPath().startsWith(summaryRoot)) {
+            return file.getPath().substring(summaryRoot.length());
+        }
+        return file.getPath();
     }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/DirectorySummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/DirectorySummaryFileTarget.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2010-2012 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.nicoulaj.maven.plugins.checksum.execution.target;
+
+import net.nicoulaj.maven.plugins.checksum.digest.DigesterFactory;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * An {@link net.nicoulaj.maven.plugins.checksum.execution.target.ExecutionTarget} that writes digests to separate
+ * files per directory.
+ *
+ * @since 1.3
+ */
+public class DirectorySummaryFileTarget
+    implements ExecutionTarget
+{
+    /**
+     * The line separator character.
+     */
+    public static final String LINE_SEPARATOR = System.getProperty( "line.separator" );
+
+    /**
+     * The CSV column separator character.
+     */
+    public static final String CSV_COLUMN_SEPARATOR = ",";
+
+    /**
+     * The CSV comment marker character.
+     */
+    public static final String CSV_COMMENT_MARKER = "#";
+
+    /**
+     * Encoding to use for generated files.
+     */
+    protected String encoding;
+
+    /**
+     * Summary filename to create in each directory.
+     */
+    protected String summaryFilename;
+
+    /**
+     * Summary path => hashed file => (algorithm,hashcode).
+     */
+    protected Map<File, Map<File, Map<String, String>>> filesHashcodes;
+
+    /**
+     * The set of algorithms encountered.
+     */
+    protected SortedSet<String> algorithms;
+
+    /**
+     * Build a new instance of {@link net.nicoulaj.maven.plugins.checksum.execution.target.DirectorySummaryFileTarget}.
+     *
+     * @param encoding the encoding to use for generated files.
+     */
+    public DirectorySummaryFileTarget(String encoding, String summaryFilename)
+    {
+        this.encoding = encoding;
+        this.summaryFilename = summaryFilename;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void init()
+        throws ExecutionTargetInitializationException
+    {
+        filesHashcodes = new HashMap<File, Map<File, Map<String, String>>>();
+        algorithms = new TreeSet<String>();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void write( String digest, File file, String algorithm )
+        throws ExecutionTargetWriteException
+    {
+        File path = new File(file.getPath().substring(0, file.getPath().length() - file.getName().length()));
+
+        // Initialize an entry for the file if needed.
+        if ( !filesHashcodes.containsKey( path ) )
+        {
+            filesHashcodes.put( path, new HashMap<File, Map<String, String>>() );
+        }
+
+        // Store the algorithm => hashcode mapping for this file.
+        Map<File, Map<String, String>> fileHashcodes = filesHashcodes.get( path );
+        if ( !fileHashcodes.containsKey( file ))
+        {
+            fileHashcodes.put( file, new HashMap<String, String>() );
+        }
+        Map<String, String> hashcodes = fileHashcodes.get( file );
+        hashcodes.put( algorithm, digest );
+
+        // Store the algorithm.
+        algorithms.add( algorithm );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void close()
+            throws ExecutionTargetCloseException
+    {
+        // Write a file for each directory.
+        for (File summaryPath : filesHashcodes.keySet()) {
+            StringBuilder sb = new StringBuilder();
+
+            // Write the CSV file header.
+            sb.append( CSV_COMMENT_MARKER ).append( "File" );
+            for ( String algorithm : algorithms )
+            {
+                sb.append( CSV_COLUMN_SEPARATOR ).append( algorithm );
+            }
+
+            // Write a line for each file.
+            for ( File file : filesHashcodes.get(summaryPath).keySet() )
+            {
+                sb.append( LINE_SEPARATOR ).append( file.getName() );
+                Map<String, String> fileHashcodes = filesHashcodes.get(summaryPath).get( file );
+                for ( String algorithm : algorithms )
+                {
+                    sb.append( CSV_COLUMN_SEPARATOR );
+                    if ( fileHashcodes.containsKey( algorithm ) )
+                    {
+                        sb.append( fileHashcodes.get( algorithm ) );
+                    }
+                }
+            }
+
+            // Write the result to the summary file.
+            try
+            {
+                FileUtils.fileWrite( summaryPath + "/" + summaryFilename, encoding, sb.toString() );
+            }
+            catch ( IOException e )
+            {
+                throw new ExecutionTargetCloseException( e.getMessage() );
+            }
+        }
+    }
+}

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/DirectorySummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/DirectorySummaryFileTarget.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.execution.target;
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.execution.target;
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/XmlSummaryFileTarget.java
@@ -59,6 +59,11 @@ public class XmlSummaryFileTarget
     protected File summaryFile;
 
     /**
+     * The root path to be removed from summary files.
+     */
+    protected String summaryRoot;
+
+    /**
      * Build a new instance of {@link net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget}.
      *
      * @param summaryFile the file to which the summary should be written.
@@ -68,6 +73,20 @@ public class XmlSummaryFileTarget
     {
         this.summaryFile = summaryFile;
         this.encoding = encoding;
+    }
+
+    /**
+     * Build a new instance of {@link net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget}.
+     *
+     * @param summaryFile the file to which the summary should be written.
+     * @param encoding    the encoding to use for generated files.
+     * @param summaryRoot the root path to remove from filepaths prior to writing to the summary file.
+     */
+    public XmlSummaryFileTarget( File summaryFile, String encoding, String summaryRoot )
+    {
+        this.summaryFile = summaryFile;
+        this.encoding = encoding;
+        this.summaryRoot = summaryRoot;
     }
 
     /**
@@ -125,7 +144,7 @@ public class XmlSummaryFileTarget
         for ( File file : filesHashcodes.keySet() )
         {
             xmlWriter.startElement( "file" );
-            xmlWriter.addAttribute( "name", file.getName() );
+            xmlWriter.addAttribute( "name", stripSummaryRoot(file) );
             Map<String, String> fileHashcodes = filesHashcodes.get( file );
             for ( String algorithm : fileHashcodes.keySet() )
             {
@@ -147,5 +166,12 @@ public class XmlSummaryFileTarget
         {
             throw new ExecutionTargetCloseException( e.getMessage() );
         }
+    }
+
+    private String stripSummaryRoot(File file) {
+        if (summaryRoot != null && file.getPath().startsWith(summaryRoot)) {
+            return file.getPath().substring(summaryRoot.length());
+        }
+        return file.getPath();
     }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.mojo;
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
@@ -21,6 +21,7 @@ import net.nicoulaj.maven.plugins.checksum.execution.ExecutionException;
 import net.nicoulaj.maven.plugins.checksum.execution.FailOnErrorExecution;
 import net.nicoulaj.maven.plugins.checksum.execution.NeverFailExecution;
 import net.nicoulaj.maven.plugins.checksum.execution.target.CsvSummaryFileTarget;
+import net.nicoulaj.maven.plugins.checksum.execution.target.DirectorySummaryFileTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.MavenLogTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.OneHashPerFileTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget;
@@ -120,17 +121,21 @@ abstract class AbstractChecksumMojo
             }
             execution.addTarget( new OneHashPerFileTarget( encoding, outputDirectory ) );
         }
+        if ( isDirectoryFiles() )
+        {
+            execution.addTarget(new DirectorySummaryFileTarget(encoding, getCsvSummaryFile()));
+        }
         if ( isCsvSummary() )
         {
             execution.addTarget( new CsvSummaryFileTarget(
                 FileUtils.resolveFile( new File( project.getBuild().getDirectory() ), getCsvSummaryFile() ),
-                encoding ) );
+                encoding, getSummaryRoot() ) );
         }
         if ( isXmlSummary() )
         {
             execution.addTarget( new XmlSummaryFileTarget(
                 FileUtils.resolveFile( new File( project.getBuild().getDirectory() ), getXmlSummaryFile() ),
-                encoding ) );
+                encoding, getSummaryRoot() ) );
         }
 
         // Run the execution.
@@ -155,6 +160,10 @@ abstract class AbstractChecksumMojo
     protected abstract boolean isIndividualFiles();
 
     protected abstract String getIndividualFilesOutputDirectory();
+
+    protected abstract boolean isDirectoryFiles();
+
+    protected abstract String getSummaryRoot();
 
     protected abstract boolean isCsvSummary();
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.mojo;
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
@@ -62,6 +62,22 @@ public class ArtifactsMojo
     protected String individualFilesOutputDirectory;
 
     /**
+     * Indicates whether the build will store checksums to per-directory summary files.
+     *
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean directoryFiles;
+
+    /**
+     * The root of the path to be stored in the summary file(s).
+     *
+     * @since 1.3
+     */
+    @Parameter
+    protected String summaryRoot;
+
+    /**
      * Indicates whether the build will store checksums to a single CSV summary file.
      *
      * @since 1.0
@@ -164,6 +180,20 @@ public class ArtifactsMojo
     protected String getIndividualFilesOutputDirectory()
     {
         return individualFilesOutputDirectory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected boolean isDirectoryFiles() {
+        return directoryFiles;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getSummaryRoot() {
+        return summaryRoot;
     }
 
     /**

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.mojo;
 

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -64,6 +64,22 @@ public class DependenciesMojo
     protected String individualFilesOutputDirectory;
 
     /**
+     * Indicates whether the build will store checksums to per-directory summary files.
+     *
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean directoryFiles;
+
+    /**
+     * The root of the path to be stored in the summary file(s).
+     *
+     * @since 1.3
+     */
+    @Parameter
+    protected String summaryRoot;
+
+    /**
      * Indicates whether the build will store checksums to a single CSV summary file.
      *
      * @since 1.0
@@ -168,6 +184,20 @@ public class DependenciesMojo
     protected String getIndividualFilesOutputDirectory()
     {
         return individualFilesOutputDirectory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected boolean isDirectoryFiles() {
+        return directoryFiles;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getSummaryRoot() {
+        return summaryRoot;
     }
 
     /**

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
@@ -91,6 +91,22 @@ public class FilesMojo
     protected String individualFilesOutputDirectory;
 
     /**
+     * Indicates whether the build will store checksums to per-directory summary files.
+     *
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean directoryFiles;
+
+    /**
+     * The root of the path to be stored in the summary file(s).
+     *
+     * @since 1.3
+     */
+    @Parameter
+    protected String summaryRoot;
+
+    /**
      * Indicates whether the build will store checksums to a single CSV summary file.
      *
      * @since 1.0
@@ -181,6 +197,20 @@ public class FilesMojo
     protected String getIndividualFilesOutputDirectory()
     {
         return individualFilesOutputDirectory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected boolean isDirectoryFiles() {
+        return directoryFiles;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getSummaryRoot() {
+        return summaryRoot;
     }
 
     /**

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions copyright 2015 ForgeRock AS
  */
 package net.nicoulaj.maven.plugins.checksum.mojo;
 


### PR DESCRIPTION
Single summary files currently write filenames rather than pathnames.  When a directory tree contains multiple files by the same name this results in conflicting entries in the summary file.  This is easily avoided by recording the full pathname of each file in the summary.

Execution of this plugin illuminates an issue with storing pathnames in that the path can contain more detail, i.e. higher parts of the tree, than desired.  This changeset includes support for 'summaryRoot', a path segment, which is removed from each pathname when writing to the summary file.

The traditional storage of checksums is in the form of a single summary file per directory. Oddly this plugin supported only 1:1 checksum files and a 1:all summary file.  This changeset adds support for a per-directory summary file, presently only in CSV form.