### PR TITLE
Fixes #30: Creates an attachChecksums property to attach checksums as build artifacts

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/AttachChecksumTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/AttachChecksumTarget.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2012 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.nicoulaj.maven.plugins.checksum.execution.target;
+
+import java.io.File;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import net.nicoulaj.maven.plugins.checksum.digest.DigesterFactory;
+
+/**
+ * An {@link ExecutionTarget} that attaches the generated checksum to the project.
+ * 
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class AttachChecksumTarget implements ExecutionTarget
+{
+   private final File outputDirectory;
+   private final MavenProject project;
+   private final MavenProjectHelper projectHelper;
+
+   public AttachChecksumTarget(File outputDirectory, MavenProject project, MavenProjectHelper projectHelper)
+   {
+      this.outputDirectory = outputDirectory;
+      this.project = project;
+      this.projectHelper = projectHelper;
+   }
+
+   @Override
+   public void init() throws ExecutionTargetInitializationException
+   {
+   }
+
+   @Override
+   public void write(String digest, File file, String algorithm) throws ExecutionTargetWriteException
+   {
+
+      try
+      {
+         File outputFileDirectory = (outputDirectory != null) ? outputDirectory : file.getParentFile();
+         String fileExtension = DigesterFactory.getInstance().getFileDigester(algorithm).getFileExtension();
+         String outputFileName = file.getName() + fileExtension;
+         File digestFile = new File(outputFileDirectory, outputFileName);
+         String artifactType = FileUtils.getExtension(file.getName()) + fileExtension;
+         projectHelper.attachArtifact(project, artifactType, digestFile);
+      }
+      catch (NoSuchAlgorithmException e)
+      {
+         throw new ExecutionTargetWriteException(e.getMessage());
+      }
+   }
+
+   @Override
+   public void close() throws ExecutionTargetCloseException
+   {
+   }
+
+}


### PR DESCRIPTION
There may be some formatting issues because I don't have the formatter used in this code.

Here is an example of a pom.xml  using this new feature :
````xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.demo2</groupId>
  <artifactId>demo2</artifactId>
  <version>1.0.0-SNAPSHOT</version>
  <packaging>war</packaging>
  <properties>
    <maven.compiler.source>1.7</maven.compiler.source>
    <maven.compiler.target>1.7</maven.compiler.target>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
  </properties>
  <build>
    <finalName>demo2</finalName>
    <plugins>
      <plugin>
        <artifactId>maven-war-plugin</artifactId>
        <version>2.4</version>
        <configuration>
          <failOnMissingWebXml>false</failOnMissingWebXml>
        </configuration>
      </plugin>
      <plugin>
        <groupId>net.ju-n.maven.plugins</groupId>
        <artifactId>checksum-maven-plugin</artifactId>
        <version>1.3-SNAPSHOT</version>
        <executions>
          <execution>
            <goals>
              <goal>artifacts</goal>
            </goals>
          </execution>
        </executions>
        <configuration>
          <attachChecksums>true</attachChecksums>
          <algorithms>
            <algorithm>MD5</algorithm>
            <algorithm>SHA-1</algorithm>
            <algorithm>SHA-256</algorithm>
          </algorithms>
        </configuration>
      </plugin>
    </plugins>
  </build>
</project>
````



