### PR TITLE
Add support for creating shasum compatible summary file

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/CsvSummaryFileTarget.java
@@ -83,6 +83,7 @@ public class CsvSummaryFileTarget
     /**
      * {@inheritDoc}
      */
+    @Override
     public void init()
     {
         filesHashcodes = new HashMap<File, Map<String, String>>();
@@ -111,6 +112,7 @@ public class CsvSummaryFileTarget
     /**
      * {@inheritDoc}
      */
+    @Override
     public void close()
         throws ExecutionTargetCloseException
     {
@@ -137,6 +139,8 @@ public class CsvSummaryFileTarget
                 }
             }
         }
+
+        sb.append( LINE_SEPARATOR );
 
         // Make sure the parent directory exists.
         FileUtils.mkdir( summaryFile.getParent() );

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/ShasumSummaryFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/ShasumSummaryFileTarget.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2010-2012 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.nicoulaj.maven.plugins.checksum.execution.target;
+
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * An {@link ExecutionTarget} that writes digests to a {@code shasum} file
+ * compatible with "{@code shasum -b -a <algo> <files> > sha.sum}". For
+ * compatibility with {@code shasum} only SHA-1, SHA-224, SHA-256, SHA-384,
+ * SHA-512, SHA-512224 and SHA-512256 are supported. Only one algorithm may be
+ * used at a time.
+ *
+ * @author <a href="mailto:julien.nicoulaud@gmail.com">Julien Nicoulaud</a>
+ * @author Mike Duigou
+ * @since 1.3
+ */
+public class ShasumSummaryFileTarget
+    implements ExecutionTarget
+{
+    /**
+     * The line separator character.
+     */
+    public static final String LINE_SEPARATOR = System.getProperty( "line.separator" );
+    /**
+     * The shasum field separator (and file type binary identifier)
+     */
+    public static final String SHASUM_FIELD_SEPARATOR = " *";
+
+    /**
+     * The shasum binary character.
+     */
+    public static final String SHASUM_BINARY_FILE = "*";
+
+    /**
+     * The association file => (algorithm,hashcode).
+     */
+    protected Map<File, Map<String, String>> filesHashcodes;
+
+    /**
+     * The set of algorithms encountered.
+     */
+    protected SortedSet<String> algorithms;
+
+    /**
+     * The target file where the summary is written.
+     */
+    protected File summaryFile;
+
+    /**
+     * Build a new instance of {@link CsvSummaryFileTarget}.
+     *
+     * @param summaryFile the file to which the summary should be written.
+     */
+    public ShasumSummaryFileTarget( File summaryFile )
+    {
+        this.summaryFile = summaryFile;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init()
+    {
+        filesHashcodes = new HashMap<File, Map<String, String>>();
+        algorithms = new TreeSet<String>();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void write( String digest, File file, String algorithm )
+    {
+        // Initialize an entry for the file if needed.
+        if ( !filesHashcodes.containsKey( file ) )
+        {
+            filesHashcodes.put( file, new HashMap<String, String>() );
+        }
+
+        // Store the algorithm => hashcode mapping for this file.
+        Map<String, String> fileHashcodes = filesHashcodes.get( file );
+        fileHashcodes.put( algorithm, digest );
+
+        // Store the algorithm.
+        algorithms.add( algorithm );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close()
+        throws ExecutionTargetCloseException
+    {
+        StringBuilder sb = new StringBuilder();
+
+        assert algorithms.size() == 1 : "Must use only one type of hash";
+
+        // Write a line for each file.
+        for ( File file : filesHashcodes.keySet() )
+        {
+            Map<String, String> fileHashcodes = filesHashcodes.get( file );
+            for ( String algorithm : algorithms )
+            {
+                if ( fileHashcodes.containsKey( algorithm ) )
+                {
+                    sb.append( fileHashcodes.get( algorithm ) );
+                }
+            }
+            sb.append(SHASUM_FIELD_SEPARATOR)
+                    .append( file.getName())
+                    .append( LINE_SEPARATOR );
+        }
+
+
+
+        // Make sure the parent directory exists.
+        FileUtils.mkdir( summaryFile.getParent() );
+
+        // Write the result to the summary file.
+        try
+        {
+            FileUtils.fileWrite( summaryFile.getPath(), "US-ASCII", sb.toString() );
+        }
+        catch ( IOException e )
+        {
+            throw new ExecutionTargetCloseException( e.getMessage() );
+        }
+    }
+}

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
@@ -24,6 +24,7 @@ import net.nicoulaj.maven.plugins.checksum.execution.target.CsvSummaryFileTarget
 import net.nicoulaj.maven.plugins.checksum.execution.target.MavenLogTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.OneHashPerFileTarget;
 import net.nicoulaj.maven.plugins.checksum.execution.target.XmlSummaryFileTarget;
+import net.nicoulaj.maven.plugins.checksum.execution.target.ShasumSummaryFileTarget;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -132,6 +133,11 @@ abstract class AbstractChecksumMojo
                 FileUtils.resolveFile( new File( project.getBuild().getDirectory() ), getXmlSummaryFile() ),
                 encoding ) );
         }
+        if ( isShasumSummary() )
+        {
+            execution.addTarget( new ShasumSummaryFileTarget(
+                FileUtils.resolveFile( new File( project.getBuild().getDirectory() ), getShasumSummaryFile() )) );
+        }
 
         // Run the execution.
         try
@@ -163,4 +169,9 @@ abstract class AbstractChecksumMojo
     protected abstract boolean isXmlSummary();
 
     protected abstract String getXmlSummaryFile();
+
+    protected abstract boolean isShasumSummary();
+
+    protected abstract String getShasumSummaryFile();
+
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
@@ -109,7 +109,7 @@ public class ArtifactsMojo
      * @see #shasumSummary
      * @since 1.3
      */
-    @Parameter( defaultValue = "artifacts-checksums.sha1" )
+    @Parameter( defaultValue = "artifacts-checksums.sha" )
     protected String shasumSummaryFile;
 
     /**

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
@@ -96,6 +96,23 @@ public class ArtifactsMojo
     protected String xmlSummaryFile;
 
     /**
+     * Indicates whether the build will store checksums to a single shasum summary file.
+     *
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean shasumSummary;
+
+    /**
+     * The name of the summary file created if the option is activated.
+     *
+     * @see #shasumSummary
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "artifacts-checksums.sha1" )
+    protected String shasumSummaryFile;
+
+    /**
      * Build the list of files from which digests should be generated.
      * <p/>
      * <p>The list is composed of the project main and attached artifacts.</p>
@@ -196,5 +213,21 @@ public class ArtifactsMojo
     protected String getXmlSummaryFile()
     {
         return xmlSummaryFile;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected boolean isShasumSummary()
+    {
+        return shasumSummary;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getShasumSummaryFile()
+    {
+        return shasumSummaryFile;
     }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -111,7 +111,7 @@ public class DependenciesMojo
      * @see #shasumSummary
      * @since 1.3
      */
-    @Parameter( defaultValue = "dependencies-checksums.sha1" )
+    @Parameter( defaultValue = "dependencies-checksums.sha" )
     protected String shasumSummaryFile;
 
     /**

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -98,6 +98,23 @@ public class DependenciesMojo
     protected String xmlSummaryFile;
 
     /**
+     * Indicates whether the build will store checksums to a single shasum summary file.
+     *
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean shasumSummary;
+
+    /**
+     * The name of the summary file created if the option is activated.
+     *
+     * @see #shasumSummary
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "artifacts-checksums.sha1" )
+    protected String shasumSummaryFile;
+
+    /**
      * The dependency scopes to include.
      * <p/>
      * <p>Allowed values are compile, test, runtime, provided and system.<br/>All scopes are included by default.</p>
@@ -200,5 +217,23 @@ public class DependenciesMojo
     protected String getXmlSummaryFile()
     {
         return xmlSummaryFile;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean isShasumSummary()
+    {
+        return shasumSummary;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getShasumSummaryFile()
+    {
+        return shasumSummaryFile;
     }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -111,7 +111,7 @@ public class DependenciesMojo
      * @see #shasumSummary
      * @since 1.3
      */
-    @Parameter( defaultValue = "artifacts-checksums.sha1" )
+    @Parameter( defaultValue = "dependencies-checksums.sha1" )
     protected String shasumSummaryFile;
 
     /**
@@ -149,6 +149,14 @@ public class DependenciesMojo
     protected List<String> types;
 
     /**
+     * Transitive dependencies or only direct dependencies.
+     *
+     * @since 1.0
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean transitive;
+
+    /**
      * Build the list of files from which digests should be generated.
      * <p/>
      * <p>The list is composed of the project dependencies.</p>
@@ -158,8 +166,9 @@ public class DependenciesMojo
     protected List<File> getFilesToProcess()
     {
         List<File> files = new LinkedList<File>();
-
-        for ( Artifact artifact : (Set<Artifact>) project.getDependencyArtifacts() )
+        @SuppressWarnings("unchecked")
+        Set<Artifact> artifacts = (Set<Artifact>) (transitive ?  project.getArtifacts() : project.getDependencyArtifacts());
+        for ( Artifact artifact : artifacts )
         {
             if ( ( scopes == null || scopes.contains( artifact.getScope() ) ) && ( types == null || types.contains(
                 artifact.getType() ) ) )

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
@@ -26,7 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Compute specified files checksum digests and store them in individual files and/or a summary file.
+ * Compute specified files checksum digests and store them in individual files
+ * and/or a summary file.
+ *
+ * The files are not filtered.
  *
  * @author <a href="mailto:julien.nicoulaud@gmail.com">Julien Nicoulaud</a>
  * @since 1.0
@@ -125,6 +128,23 @@ public class FilesMojo
     protected String xmlSummaryFile;
 
     /**
+     * Indicates whether the build will store checksums to a single shasum summary file.
+     *
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean shasumSummary;
+
+    /**
+     * The name of the summary file created if the option is activated.
+     *
+     * @see #shasumSummary
+     * @since 1.3
+     */
+    @Parameter( defaultValue = "artifacts-checksums.sha1" )
+    protected String shasumSummaryFile;
+
+    /**
      * Build the list of files from which digests should be generated.
      *
      * @return the list of files that should be processed.
@@ -158,11 +178,11 @@ public class FilesMojo
 
             scanner.scan();
 
-            for ( String filePath : scanner.getIncludedFiles() )
-            {
+                for ( String filePath : scanner.getIncludedFiles() )
+                {
                 filesToProcess.add( new File( fileSet.getDirectory(), filePath ) );
             }
-        }
+            }
 
         return filesToProcess;
     }
@@ -213,5 +233,21 @@ public class FilesMojo
     protected String getXmlSummaryFile()
     {
         return xmlSummaryFile;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected boolean isShasumSummary()
+    {
+        return shasumSummary;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getShasumSummaryFile()
+    {
+        return shasumSummaryFile;
     }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
@@ -141,7 +141,7 @@ public class FilesMojo
      * @see #shasumSummary
      * @since 1.3
      */
-    @Parameter( defaultValue = "artifacts-checksums.sha1" )
+    @Parameter( defaultValue = "checksums.sha" )
     protected String shasumSummaryFile;
 
     /**


### PR DESCRIPTION
Adds the ability to create a summary file in the format used by shasum shell tool.

Also adds a terminating carriage return to the CSV summary file so that multiple CSV files can be more easily merged via concatenation.

Adds the ability to get transitive dependencies to dependencies mojo.