### PR TITLE
fix bug - wrong checksum of empty or very short file

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/digest/CksumFileDigester.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/digest/CksumFileDigester.java
@@ -61,7 +61,7 @@ public class CksumFileDigester
 		    	value = value << 8 ^ CRC_TAB[(value >> 24 ^ (int)(length & 0xFF)) & 0xFF];
 		    	length >>= 8;
 		    }
-		    return Long.toString((value ^ 0xFFFFFFFF) & 0xFFFFFFFF);
+		    return Long.toString((value ^ 0xFFFFFFFFL) & 0xFFFFFFFFL);
 		} 
 		catch ( IOException e )
 		{

--- a/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/digest/CksumFileDigesterTest.java
+++ b/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/digest/CksumFileDigesterTest.java
@@ -1,0 +1,26 @@
+package net.nicoulaj.maven.plugins.checksum.test.unit.digest;
+
+
+import junit.framework.TestCase;
+import net.nicoulaj.maven.plugins.checksum.digest.CksumFileDigester;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * Created by tsumaraa on 03/12/2015.
+ */
+public class CksumFileDigesterTest  {
+
+    @Test
+    public void testEmptyFileCksum() throws Exception {
+        File empty_file = File.createTempFile("empty_file", null);
+
+        CksumFileDigester cksumDigester=new CksumFileDigester();
+        String cksumEmpty = cksumDigester.calculate(empty_file);
+
+        Assert.assertEquals("4294967295", cksumEmpty);
+
+    }
+}

--- a/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/digest/CksumFileDigesterTest.java
+++ b/src/test/java/net/nicoulaj/maven/plugins/checksum/test/unit/digest/CksumFileDigesterTest.java
@@ -9,7 +9,8 @@ import org.junit.Test;
 import java.io.File;
 
 /**
- * Created by tsumaraa on 03/12/2015.
+ * Special testcase for cksum {@link CksumFileDigester} of the empty file
+ *
  */
 public class CksumFileDigesterTest  {
 


### PR DESCRIPTION
Hello nicoulaj,
 I come across your implementation of cksum. Unfortunately it contains bug for small or empty files. Want to submit test evidence and fix.