### PR TITLE
update appendFilename option to work with sha1sum -c unix command

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/OneHashPerFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/OneHashPerFileTarget.java
@@ -131,7 +131,7 @@ public class OneHashPerFileTarget
             File outputFile = new File(outputFileDirectory.getPath(), outputFileName);
             StringBuilder digestToPrint = new StringBuilder(digest);
             if(appendFilename){
-                digestToPrint.append(" ");
+                digestToPrint.append("\t");
                 digestToPrint.append(file.getFile().getName());
             }
             FileUtils.fileWrite( outputFile, digestToPrint.toString() );


### PR DESCRIPTION
Hello,

I update the appendFilename option to work with unix control command like sha1sulm -c.
Could you integrate it to the official next version ?

Regards,
hlaunay