### PR TITLE
#40: Maven's ProjectHelper expects a type without leading dot.

### DIFF
--- a/src/it/projects/single-artifact/artifacts/attach-checksums/invoker.properties
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/invoker.properties
@@ -1,0 +1,72 @@
+#
+# Copyright 2010-2016 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean install
+
+# Optionally, a list of goals to run during further invocations of Maven
+# invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:run
+
+# A comma or space separated list of profiles to activate
+# invoker.profiles = its,jdk15
+
+# The path to an alternative POM or base directory to invoke Maven on, defaults to the
+# project that was originally specified in the plugin configuration
+# Since plugin version 1.4
+# invoker.project = sub-module
+
+# The value for the environment variable MAVEN_OPTS
+# invoker.mavenOpts = -Dfile.encoding=UTF-16 -Xms32m -Xmx256m
+
+# Possible values are "fail-fast" (default), "fail-at-end" and "fail-never"
+# invoker.failureBehavior = fail-never
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+# invoker.buildResult = failure
+
+# A boolean value controlling the aggregator mode of Maven, defaults to "false"
+# invoker.nonRecursive = true
+
+# A boolean value controlling the network behavior of Maven, defaults to "false"
+# Since plugin version 1.4
+# invoker.offline = true
+
+# The path to the properties file from which to load system properties, defaults to the
+# filename given by the plugin parameter testPropertiesFile
+# Since plugin version 1.4
+# invoker.systemPropertiesFile = test.properties
+
+# An optional human friendly name for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.name = single-artifact/artifacts/attach-checksums
+
+# An optional description for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.description = A single artifact project / goal "artifacts" / configuration attaching the checksums.
+
+# A comma separated list of JRE versions on which this build job should be run.
+# Since plugin version 1.4
+# invoker.java.version = 1.4+, !1.4.1, 1.7-
+
+# A comma separated list of OS families on which this build job should be run.
+# Since plugin version 1.4
+# invoker.os.family = !windows, unix, mac
+
+# A comma separated list of Maven versions on which this build should be run.
+# Since plugin version 1.5
+# invoker.maven.version = 2.0.10+, !2.1.0, !2.2.0

--- a/src/it/projects/single-artifact/artifacts/attach-checksums/pom.xml
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2010-2016 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.ju-n.maven.plugins.checksum.test.projects</groupId>
+  <artifactId>single-artifact.artifacts.attach-checksums</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.ju-n.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>artifacts</goal>
+            </goals>
+            <configuration>
+              <attachChecksums>true</attachChecksums>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/single-artifact/artifacts/attach-checksums/postbuild.groovy
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/postbuild.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2016 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net.nicoulaj.maven.plugins.checksum.test.integration.PostBuildScriptHelper
+
+try
+{
+  // Instantiate a helper.
+  PostBuildScriptHelper helper = new PostBuildScriptHelper( basedir, localRepositoryPath, context )
+
+  // Fail if no traces of checksum-maven-plugin invocation.
+  helper.assertBuildLogContains( "checksum-maven-plugin" );
+
+  // Check files have been created and are not empty.
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.md5" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha1" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/ju-n/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.md5" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/ju-n/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.sha1" )
+
+}
+catch ( Exception e )
+{
+  System.err.println( e.getMessage() )
+  return false;
+}

--- a/src/it/projects/single-artifact/artifacts/attach-checksums/src/main/java/Main.java
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/src/main/java/Main.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2016 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Just an "hello world" class.
+ */
+class Main
+{
+    /**
+     * Print "Hello world".
+     *
+     * @param args arguments
+     */
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactAttacher.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactAttacher.java
@@ -16,6 +16,10 @@ public class ArtifactAttacher implements ArtifactListener {
 
     @Override
     public void artifactCreated(File artifact, String type) {
+        if (type.startsWith(".")) {
+            // Project helper expects a type without leading dot (e.g. turn ".md5" into "md5").
+            type = type.substring(1);
+        }
         projectHelper.attachArtifact(project, type, null, artifact);
     }
 }

--- a/src/test/java/net/nicoulaj/maven/plugins/checksum/test/integration/PostBuildScriptHelper.java
+++ b/src/test/java/net/nicoulaj/maven/plugins/checksum/test/integration/PostBuildScriptHelper.java
@@ -134,7 +134,25 @@ public class PostBuildScriptHelper
     public void assertFileIsNotEmpty( String path )
         throws Exception
     {
-        File file = new File( baseDirectory, path );
+        assertFileIsNotEmptyRelativeTo( baseDirectory, path );
+    }
+
+    /**
+     * Assert the given file exists and is a non-empty file.
+     *
+     * @param path the path to the file relative to {@link #localRepositoryPath}.
+     * @throws Exception  if conditions are not fulfilled.
+     */
+    public void assertFileIsNotEmptyInLocalRepo( String path )
+        throws Exception
+    {
+        assertFileIsNotEmptyRelativeTo(localRepositoryPath, path);
+    }
+
+	private void assertFileIsNotEmptyRelativeTo( File directory, String path )
+        throws Exception
+    {
+        File file = new File( directory, path );
         if ( !file.isFile() )
         {
             throw new Exception( "The file " + path + " is missing or not a file." );


### PR DESCRIPTION
Adding PR, with an integration test verifying the behaviour.