### PR TITLE
DependencyResolution for the dependency MOJO causes NPE

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -37,7 +37,7 @@ import java.util.Set;
     defaultPhase = LifecyclePhase.VERIFY,
     requiresProject = true,
     inheritByDefault = false,
-    requiresDependencyResolution = ResolutionScope.RUNTIME,
+    requiresDependencyResolution = ResolutionScope.TEST,
     threadSafe = true )
 public class DependenciesMojo
     extends AbstractChecksumMojo


### PR DESCRIPTION
Running the plugin in test-scope leads to an NPE, due to the dependencies for test not being resolved. f

Failing test case can be found here: 
https://github.com/kaiinkinen/checksum-plugin-failing-test

This can be alleviated by changing the resolution to use test-scope for all executions. 

The fix simple changes the resolution scope, but comes with no other changes. 