### PR TITLE
added failIfNoFiles boolean configuration for files

### DIFF
--- a/src/it/projects/single-pom/files/filesets-nofiles-nofail/invoker.properties
+++ b/src/it/projects/single-pom/files/filesets-nofiles-nofail/invoker.properties
@@ -1,0 +1,73 @@
+#
+# checksum-maven-plugin - http://checksum-maven-plugin.nicoulaj.net
+# Copyright © 2010-2017 checksum-maven-plugin contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean install
+
+# Optionally, a list of goals to run during further invocations of Maven
+# invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:run
+
+# A comma or space separated list of profiles to activate
+# invoker.profiles = its,jdk15
+
+# The path to an alternative POM or base directory to invoke Maven on, defaults to the
+# project that was originally specified in the plugin configuration
+# Since plugin version 1.4
+# invoker.project = sub-module
+
+# The value for the environment variable MAVEN_OPTS
+# invoker.mavenOpts = -Dfile.encoding=UTF-16 -Xms32m -Xmx256m
+
+# Possible values are "fail-fast" (default), "fail-at-end" and "fail-never"
+# invoker.failureBehavior = fail-never
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success
+
+# A boolean value controlling the aggregator mode of Maven, defaults to "false"
+# invoker.nonRecursive = true
+
+# A boolean value controlling the network behavior of Maven, defaults to "false"
+# Since plugin version 1.4
+# invoker.offline = true
+
+# The path to the properties file from which to load system properties, defaults to the
+# filename given by the plugin parameter testPropertiesFile
+# Since plugin version 1.4
+# invoker.systemPropertiesFile = test.properties
+
+# An optional human friendly name for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.name = single-pom/files/filesets-nofile-nofail
+
+# An optional description for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.description = A single pom project / goal "files" / filesets nofiles no failure config.
+
+# A comma separated list of JRE versions on which this build job should be run.
+# Since plugin version 1.4
+# invoker.java.version = 1.4+, !1.4.1, 1.7-
+
+# A comma separated list of OS families on which this build job should be run.
+# Since plugin version 1.4
+# invoker.os.family = !windows, unix, mac
+
+# A comma separated list of Maven versions on which this build should be run.
+# Since plugin version 1.5
+# invoker.maven.version = 2.0.10+, !2.1.0, !2.2.0

--- a/src/it/projects/single-pom/files/filesets-nofiles-nofail/pom.xml
+++ b/src/it/projects/single-pom/files/filesets-nofiles-nofail/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    checksum-maven-plugin - http://checksum-maven-plugin.nicoulaj.net
+    Copyright © 2010-2017 checksum-maven-plugin contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.nicoulaj.maven.plugins.checksum.test.projects</groupId>
+  <artifactId>single-pom.files.filesets</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>files</goal>
+            </goals>
+            <configuration>
+              <failIfNoFiles>false</failIfNoFiles>
+              <fileSets>
+                <fileSet>
+                  <directory>.</directory>
+                  <includes>
+                    <include>*.txt</include><!-- no file expected to match -->
+                  </includes>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/single-pom/files/filesets-nofiles-nofail/postbuild.groovy
+++ b/src/it/projects/single-pom/files/filesets-nofiles-nofail/postbuild.groovy
@@ -1,0 +1,36 @@
+/**
+ * checksum-maven-plugin - http://checksum-maven-plugin.nicoulaj.net
+ * Copyright © 2010-2017 checksum-maven-plugin contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import net.nicoulaj.maven.plugins.checksum.test.integration.PostBuildScriptHelper
+
+try
+{
+  // Instantiate a helper.
+  PostBuildScriptHelper helper = new PostBuildScriptHelper( basedir, localRepositoryPath, context )
+
+  // Fail if there are warnings
+  helper.assertBuildLogDoesNotContain('[WARNING]')
+  helper.assertBuildLogDoesNotContain('[ERROR]')
+
+  // Fail if no traces of checksum-maven-plugin invocation.
+  helper.assertBuildLogContains( "checksum-maven-plugin" );
+
+}
+catch ( Exception e )
+{
+  System.err.println( e.getMessage() )
+  return false;
+}

--- a/src/it/projects/single-pom/files/filesets-nofiles/invoker.properties
+++ b/src/it/projects/single-pom/files/filesets-nofiles/invoker.properties
@@ -1,0 +1,73 @@
+#
+# checksum-maven-plugin - http://checksum-maven-plugin.nicoulaj.net
+# Copyright © 2010-2017 checksum-maven-plugin contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean install
+
+# Optionally, a list of goals to run during further invocations of Maven
+# invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:run
+
+# A comma or space separated list of profiles to activate
+# invoker.profiles = its,jdk15
+
+# The path to an alternative POM or base directory to invoke Maven on, defaults to the
+# project that was originally specified in the plugin configuration
+# Since plugin version 1.4
+# invoker.project = sub-module
+
+# The value for the environment variable MAVEN_OPTS
+# invoker.mavenOpts = -Dfile.encoding=UTF-16 -Xms32m -Xmx256m
+
+# Possible values are "fail-fast" (default), "fail-at-end" and "fail-never"
+# invoker.failureBehavior = fail-never
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = failure
+
+# A boolean value controlling the aggregator mode of Maven, defaults to "false"
+# invoker.nonRecursive = true
+
+# A boolean value controlling the network behavior of Maven, defaults to "false"
+# Since plugin version 1.4
+# invoker.offline = true
+
+# The path to the properties file from which to load system properties, defaults to the
+# filename given by the plugin parameter testPropertiesFile
+# Since plugin version 1.4
+# invoker.systemPropertiesFile = test.properties
+
+# An optional human friendly name for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.name = single-pom/files/filesets-nofile
+
+# An optional description for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.description = A single pom project / goal "files" / filesets nofiles failure.
+
+# A comma separated list of JRE versions on which this build job should be run.
+# Since plugin version 1.4
+# invoker.java.version = 1.4+, !1.4.1, 1.7-
+
+# A comma separated list of OS families on which this build job should be run.
+# Since plugin version 1.4
+# invoker.os.family = !windows, unix, mac
+
+# A comma separated list of Maven versions on which this build should be run.
+# Since plugin version 1.5
+# invoker.maven.version = 2.0.10+, !2.1.0, !2.2.0

--- a/src/it/projects/single-pom/files/filesets-nofiles/pom.xml
+++ b/src/it/projects/single-pom/files/filesets-nofiles/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    checksum-maven-plugin - http://checksum-maven-plugin.nicoulaj.net
+    Copyright © 2010-2017 checksum-maven-plugin contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.nicoulaj.maven.plugins.checksum.test.projects</groupId>
+  <artifactId>single-pom.files.filesets</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>files</goal>
+            </goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <directory>.</directory>
+                  <includes>
+                    <include>*.txt</include><!-- no file expected to match -->
+                  </includes>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/single-pom/files/filesets-nofiles/postbuild.groovy
+++ b/src/it/projects/single-pom/files/filesets-nofiles/postbuild.groovy
@@ -1,0 +1,35 @@
+/**
+ * checksum-maven-plugin - http://checksum-maven-plugin.nicoulaj.net
+ * Copyright © 2010-2017 checksum-maven-plugin contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import net.nicoulaj.maven.plugins.checksum.test.integration.PostBuildScriptHelper
+
+try
+{
+  // Instantiate a helper.
+  PostBuildScriptHelper helper = new PostBuildScriptHelper( basedir, localRepositoryPath, context )
+
+  // Fail if there are warnings
+  helper.assertBuildLogDoesNotContain('[WARNING]')
+
+  // Fail if error message not found.
+  helper.assertBuildLogContains( "[ERROR] No file to process." );
+
+}
+catch ( Exception e )
+{
+  System.err.println( e.getMessage() )
+  return false;
+}

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/AbstractChecksumMojo.java
@@ -52,7 +52,7 @@ abstract class AbstractChecksumMojo
     /**
      * Fail if no files no process.
      */
-    private final boolean failIfNoFiles;
+    private boolean defaultFailIfNoFiles;
 
     /**
      * Fail if no files no process.
@@ -160,7 +160,7 @@ abstract class AbstractChecksumMojo
      * @param failIfNoTargets fail if no targets to process
      */
     AbstractChecksumMojo(boolean failIfNoFiles, boolean failIfNoAlgorithms, boolean failIfNoTargets) {
-        this.failIfNoFiles = failIfNoFiles;
+        this.defaultFailIfNoFiles = failIfNoFiles;
         this.failIfNoAlgorithms = failIfNoAlgorithms;
         this.failIfNoTargets = failIfNoTargets;
     }
@@ -176,7 +176,7 @@ abstract class AbstractChecksumMojo
         Execution execution = ( failOnError ) ? new FailOnErrorExecution() : new NeverFailExecution( getLog() );
         execution.setAlgorithms( algorithms );
         execution.setFiles( getFilesToProcess() );
-        execution.setFailIfNoFiles(failIfNoFiles);
+        execution.setFailIfNoFiles(isFailIfNoFiles());
         execution.setFailIfNoAlgorithms(failIfNoAlgorithms);
         execution.setFailIfNoTargets(failIfNoTargets);
         if ( !quiet )
@@ -263,4 +263,7 @@ abstract class AbstractChecksumMojo
 
     protected abstract String getShasumSummaryFile();
 
+    protected boolean isFailIfNoFiles(){
+        return defaultFailIfNoFiles;
+    }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/FilesMojo.java
@@ -146,6 +146,14 @@ public class FilesMojo
     protected String shasumSummaryFile;
 
     /**
+     * Fail if no file found to calculate checksum.
+     *
+     * @since 1.7
+     */
+    @Parameter( defaultValue = "true" )
+    protected boolean failIfNoFiles;
+
+    /**
      * Constructor.
      */
     public FilesMojo() {
@@ -268,5 +276,13 @@ public class FilesMojo
     protected String getShasumSummaryFile()
     {
         return shasumSummaryFile;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean isFailIfNoFiles(){
+        return failIfNoFiles;
     }
 }


### PR DESCRIPTION
feature useful when using this plugin in Apache parent POM to calculate source release checksums
see https://issues.apache.org/jira/browse/MPOM-205

currently, I had to configure failOnError to avoid expected missing files (source release is only done at root module)