### PR TITLE
Require checking scopes and types conditions in all cases.

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesCheckMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesCheckMojo.java
@@ -217,8 +217,8 @@ public class DependenciesCheckMojo extends AbstractMojo
     Set<Artifact> artifacts = transitive ? project.getArtifacts() : project.getDependencyArtifacts();
     for ( Artifact artifact : artifacts )
     {
-      if ((!allProjectModules.contains(artifact)) || (scopes == null || scopes.contains(artifact.getScope()))
-                                                     && (types == null || types.contains(artifact.getType())))
+      if (!allProjectModules.contains(artifact) && (scopes == null || scopes.contains(artifact.getScope()))
+          && (types == null || types.contains(artifact.getType())))
       {
         getLog().debug(String.format("check artifact %s", artifact));
         result.add(artifact);


### PR DESCRIPTION
The 'or' ('||') condition causes `scope`/`type` conditions to be ignored in some cases. This fixes the conditional in the if-statement, such that filtering behaves appropriately and the right subset of dependencies are discovered and processed.