### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 
 jdk:
   - openjdk8
-  - oraclejdk9
   - openjdk9
   - openjdk10
   - openjdk11
+  - openjdk12
 env:
   - MAVEN=3.0.5
   - MAVEN=3.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 jdk:
   - openjdk8
-  - openjdk9
   - openjdk10
   - openjdk11
   - openjdk12


### PR DESCRIPTION
Add openjdk12 for matrix build
Remove oracle jdk since it is no longer available in Travis