### PR TITLE
use correct filename in repos for checksums of attached artifacts

### DIFF
--- a/src/it/projects/single-artifact/artifacts/attach-checksums/pom.xml
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/pom.xml
@@ -66,6 +66,11 @@
             </goals>
             <configuration>
               <attachChecksums>true</attachChecksums>
+              <algorithms>
+                <!-- use non standard algorithm to verify really checksums of this plugin and not of maven-install-plugin -->
+                <algorithm>SHA-256</algorithm>
+                <algorithm>SHA-512</algorithm>
+              </algorithms>
             </configuration>
           </execution>
         </executions>

--- a/src/it/projects/single-artifact/artifacts/attach-checksums/pom.xml
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/pom.xml
@@ -41,6 +41,20 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <!-- type = java-source (https://github.com/apache/maven-source-plugin/blob/b677bb8bd173c621ec3c28842aa296f8c149f059/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java#L519) -->
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>net.nicoulaj.maven.plugins</groupId>
         <artifactId>checksum-maven-plugin</artifactId>

--- a/src/it/projects/single-artifact/artifacts/attach-checksums/postbuild.groovy
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/postbuild.groovy
@@ -29,14 +29,14 @@ try
   helper.assertBuildLogContains( "checksum-maven-plugin" );
 
   // Check files have been created and are not empty.
-  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.md5" )
-  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha1" )
-  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.md5" )
-  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha1" )
-  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.md5" )
-  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha1" )
-  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.md5" )
-  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha1" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha512" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha256" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha512" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha256" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha512" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha256" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha512" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha256" )
 
 }
 catch ( Exception e )

--- a/src/it/projects/single-artifact/artifacts/attach-checksums/postbuild.groovy
+++ b/src/it/projects/single-artifact/artifacts/attach-checksums/postbuild.groovy
@@ -31,8 +31,12 @@ try
   // Check files have been created and are not empty.
   helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.md5" )
   helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha1" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.md5" )
+  helper.assertFileIsNotEmpty( "target/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha1" )
   helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.md5" )
   helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT.jar.sha1" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.md5" )
+  helper.assertFileIsNotEmptyInLocalRepo( "net/nicoulaj/maven/plugins/checksum/test/projects/single-artifact.artifacts.attach-checksums/1.0-SNAPSHOT/single-artifact.artifacts.attach-checksums-1.0-SNAPSHOT-sources.jar.sha1" )
 
 }
 catch ( Exception e )

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactAttacher.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactAttacher.java
@@ -31,14 +31,13 @@ public class ArtifactAttacher implements ArtifactListener {
     }
 
     @Override
-    public void artifactCreated(File artifact, String checksumType, String artifactType, String artifactClassifier) {
+    public void artifactCreated(File artifact, String checksumType, String artifactExtension, String artifactClassifier) {
         if (checksumType.startsWith(".")) {
             // Project helper expects a type without leading dot (e.g. turn ".md5" into "md5").
             checksumType = checksumType.substring(1);
         }
 
-        String attachmentType = artifactType == null ? checksumType : artifactType + "." + checksumType;
-
-        projectHelper.attachArtifact(project, attachmentType, artifactClassifier, artifact);
+        String checksumArtifactType = artifactExtension + "." + checksumType;
+        projectHelper.attachArtifact(project, checksumArtifactType, artifactClassifier, artifact);
     }
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactListener.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/artifacts/ArtifactListener.java
@@ -19,5 +19,5 @@ package net.nicoulaj.maven.plugins.checksum.artifacts;
 import java.io.File;
 
 public interface ArtifactListener {
-    void artifactCreated(File artifact, String checksumType, String artifactType, String artifactClassifier);
+    void artifactCreated(File artifact, String checksumType, String artifactExtension, String artifactClassifier);
 }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/OneHashPerFileTarget.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/execution/target/OneHashPerFileTarget.java
@@ -143,7 +143,7 @@ public class OneHashPerFileTarget
             FileUtils.fileWrite( outputFile, digestToPrint.toString() );
 
             for (ArtifactListener artifactListener : artifactListeners) {
-                artifactListener.artifactCreated(outputFile, fileExtension, file.getType(), file.getClassifier());
+                artifactListener.artifactCreated(outputFile, fileExtension, file.getExtension(), file.getClassifier());
             }
         }
         catch ( IOException | NoSuchAlgorithmException e )

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ArtifactsMojo.java
@@ -145,7 +145,7 @@ public class ArtifactsMojo
         // Add project main artifact.
         if ( hasValidFile( project.getArtifact() ) )
         {
-            files.add( new ChecksumFile( "", project.getArtifact().getFile(), project.getArtifact().getType(),null ) );
+            files.add( new ChecksumFile( "", project.getArtifact().getFile(), project.getArtifact().getArtifactHandler().getExtension(), null ) );
         }
 
         // Add projects attached.
@@ -155,7 +155,7 @@ public class ArtifactsMojo
             {
                 if ( hasValidFile( artifact ) )
                 {
-                    files.add( new ChecksumFile( "", artifact.getFile(), artifact.getType(), artifact.getClassifier() ) );
+                    files.add( new ChecksumFile( "", artifact.getFile(), artifact.getArtifactHandler().getExtension(), artifact.getClassifier() ) );
                 }
             }
         }

--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ChecksumFile.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/ChecksumFile.java
@@ -30,15 +30,15 @@ public class ChecksumFile
 
     protected final File file;
 
-    protected final String type;
+    protected final String extension;
 
     protected final String classifier;
 
-	public ChecksumFile(String basePath, File file, String type, String classifier)
+	public ChecksumFile(String basePath, File file, String extension, String classifier)
 	{
 		this.basePath = basePath;
         this.file = file;
-        this.type = type;
+        this.extension = extension;
         this.classifier = classifier;
 	}
 
@@ -52,9 +52,9 @@ public class ChecksumFile
         return file;
     }
 
-    public String getType()
+    public String getExtension()
     {
-        return type;
+        return extension;
     }
 
     public String getClassifier()


### PR DESCRIPTION
in case type != extension (e.g. for maven-source-plugin) the resulting
attached artifact must not use type but extension of the original
artifact

This closes #63