### PR TITLE
Enable the "transitive" property

### DIFF
--- a/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
+++ b/src/main/java/net/nicoulaj/maven/plugins/checksum/mojo/DependenciesMojo.java
@@ -152,7 +152,7 @@ public class DependenciesMojo
      *
      * @since 1.0
      */
-    @Parameter( defaultValue = "false" )
+    @Parameter( property = "transitive", defaultValue = "false" )
     protected boolean transitive;
 
     /**


### PR DESCRIPTION
Makes the `DependenciesMojo` able to include transitive dependencies when creating checksums